### PR TITLE
Weight on-cpu samples by period rather than timestamp delta

### DIFF
--- a/src/import/stackprof.ts
+++ b/src/import/stackprof.ts
@@ -1,7 +1,7 @@
 // https://github.com/tmm1/stackprof
 
 import {Profile, FrameInfo, StackListProfileBuilder} from '../lib/profile'
-import {TimeFormatter} from '../lib/value-formatters'
+import {RawValueFormatter, TimeFormatter} from '../lib/value-formatters'
 
 interface StackprofFrame {
   name: string
@@ -15,14 +15,13 @@ export interface StackprofProfile {
   raw: number[]
   raw_timestamp_deltas: number[]
   samples: number
+  interval: number
 }
 
 export function importFromStackprof(stackprofProfile: StackprofProfile): Profile {
-  const {frames, mode, raw, raw_timestamp_deltas, samples} = stackprofProfile
-  const objectMode = mode == 'object'
-
-  const size = objectMode ? samples : stackprofProfile.raw_timestamp_deltas.reduce((a, b) => a + b, 0)
-  const profile = new StackListProfileBuilder(size)
+  const {frames, mode, raw, raw_timestamp_deltas, interval} = stackprofProfile
+  const profile = new StackListProfileBuilder()
+  profile.setValueFormatter(new TimeFormatter('microseconds')) // default to time format unless we're in object mode
 
   let sampleIndex = 0
 
@@ -44,22 +43,23 @@ export function importFromStackprof(stackprofProfile: StackprofProfile): Profile
     }
     const nSamples = raw[i++]
 
-    if (objectMode) {
-      profile.appendSampleWithWeight(stack, nSamples)
-    } else {
-      let sampleDuration = 0
-      for (let j = 0; j < nSamples; j++) {
-        sampleDuration += raw_timestamp_deltas[sampleIndex++]
-      }
-
-      profile.appendSampleWithWeight(stack, sampleDuration)
+    switch (mode) {
+      case 'object':
+        profile.appendSampleWithWeight(stack, nSamples)
+        profile.setValueFormatter(new RawValueFormatter())
+        break
+      case 'cpu':
+        profile.appendSampleWithWeight(stack, nSamples * interval)
+        break
+      default:
+        let sampleDuration = 0
+        for (let j = 0; j < nSamples; j++) {
+          sampleDuration += raw_timestamp_deltas[sampleIndex++]
+        }
+        profile.appendSampleWithWeight(stack, sampleDuration)
     }
 
     prevStack = stack
-  }
-
-  if (!objectMode) {
-    profile.setValueFormatter(new TimeFormatter('microseconds'))
   }
 
   return profile.build()


### PR DESCRIPTION
This attempts to improve the quality of the on-CPU profiles stackprof provides. Rather than weighing samples by their timestamp deltas, which, in our opinion, are only valid in wall-clock mode, this weighs callchains by:


```
S = number of samples
P = sample period in nanoseconds

W = S * P
```

The difference after this change is quite substantial, specially in profiles that previously were showing up with heavy IO frames:  

* Total profile weight is almost down by 90%, which actually makes sense for an on-CPU profile if the app is relatively idle
* Certain callchains that blocked in syscalls / IO are now much lower weight. This was what I was expecting to find.
Here is an example of the latter point.

In delta mode, we see an io select taking a long time, it is a significant portion of the profile:

<img width="1100" alt="236936508-709bee01-d616-4246-ba74-ab004331dcd3" src="https://github.com/dalehamel/speedscope/assets/4398256/39140f1e-50a9-4f33-8a61-ec98b6273fd4">

But in period scaling mode, it is only a couple of sample periods ultimately:

<img width="206" alt="236936693-9d44304e-a1c2-4906-b3c8-50e19e6f9f27" src="https://github.com/dalehamel/speedscope/assets/4398256/7d19077f-ef25-4d79-980b-cfa1775d928d">
