### PR TITLE
Build stackprof frame key with rhudimentary "hash"

### DIFF
--- a/src/import/__snapshots__/stackprof.test.ts.snap
+++ b/src/import/__snapshots__/stackprof.test.ts.snap
@@ -6,7 +6,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "sample/programs/ruby/simple.rb",
-      "key": "350771101040640",
+      "key": 640024576,
       "line": undefined,
       "name": "<main>",
       "selfWeight": 0,
@@ -15,7 +15,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/mcorrea/src/github.com/dalehamel/speedscope/sample/programs/ruby/simple.rb",
-      "key": "296902734643200",
+      "key": -1125122048,
       "line": undefined,
       "name": "<main>",
       "selfWeight": 0,
@@ -24,7 +24,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/mcorrea/src/github.com/dalehamel/speedscope/sample/programs/ruby/simple.rb",
-      "key": "296909975060517",
+      "key": -77520807,
       "line": 37,
       "name": "block in <main>",
       "selfWeight": 0,
@@ -33,7 +33,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/mcorrea/src/github.com/dalehamel/speedscope/sample/programs/ruby/simple.rb",
-      "key": "349694268538884",
+      "key": -195885932,
       "line": 4,
       "name": "Object#a",
       "selfWeight": 0,
@@ -42,7 +42,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/mcorrea/src/github.com/dalehamel/speedscope/sample/programs/ruby/simple.rb",
-      "key": "349694265917452",
+      "key": -74773060,
       "line": 12,
       "name": "Object#b",
       "selfWeight": 0,
@@ -51,7 +51,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/mcorrea/src/github.com/dalehamel/speedscope/sample/programs/ruby/simple.rb",
-      "key": "349694192517144",
+      "key": 65739640,
       "line": 24,
       "name": "Object#d",
       "selfWeight": 331000,
@@ -60,7 +60,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/mcorrea/src/github.com/dalehamel/speedscope/sample/programs/ruby/simple.rb",
-      "key": "349694234460178",
+      "key": -1251274598,
       "line": 18,
       "name": "Object#c",
       "selfWeight": 0,
@@ -69,7 +69,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/mcorrea/src/github.com/dalehamel/speedscope/sample/programs/ruby/simple.rb",
-      "key": "349694189895712",
+      "key": 117646496,
       "line": 32,
       "name": "Object#e",
       "selfWeight": 79000,
@@ -78,7 +78,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "",
-      "key": "65536",
+      "key": 2031616,
       "line": undefined,
       "name": "(garbage collection)",
       "selfWeight": 0,
@@ -87,7 +87,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "",
-      "key": "327680",
+      "key": 10158080,
       "line": undefined,
       "name": "(sweeping)",
       "selfWeight": 71000,
@@ -96,7 +96,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "",
-      "key": "196608",
+      "key": 6094848,
       "line": undefined,
       "name": "(marking)",
       "selfWeight": 8000,
@@ -454,7 +454,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "simple.rb",
-      "key": "4594002315130961920",
+      "key": 1997471744,
       "line": undefined,
       "name": "<main>",
       "selfWeight": 0,
@@ -463,7 +463,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/jlfwong/code/speedscope/sample/programs/ruby/simple.rb",
-      "key": "4594003398135644160",
+      "key": 451936256,
       "line": undefined,
       "name": "<main>",
       "selfWeight": 0,
@@ -472,7 +472,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/jlfwong/code/speedscope/sample/programs/ruby/simple.rb",
-      "key": "4594002586824867871",
+      "key": 1301748603,
       "line": 31,
       "name": "block in <main>",
       "selfWeight": 0,
@@ -481,7 +481,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/jlfwong/code/speedscope/sample/programs/ruby/simple.rb",
-      "key": "4594002590818631684",
+      "key": 420218004,
       "line": 4,
       "name": "Object#a",
       "selfWeight": 0,
@@ -490,7 +490,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/jlfwong/code/speedscope/sample/programs/ruby/simple.rb",
-      "key": "4594002590817320971",
+      "key": 479726231,
       "line": 11,
       "name": "Object#b",
       "selfWeight": 0,
@@ -499,7 +499,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/jlfwong/code/speedscope/sample/programs/ruby/simple.rb",
-      "key": "4594002590814699543",
+      "key": 29365331,
       "line": 23,
       "name": "Object#d",
       "selfWeight": 1087582,
@@ -508,7 +508,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "",
-      "key": "20512768",
+      "key": 635895808,
       "line": undefined,
       "name": "(garbage collection)",
       "selfWeight": 464022,
@@ -517,7 +517,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/jlfwong/code/speedscope/sample/programs/ruby/simple.rb",
-      "key": "4594002590816010257",
+      "key": 36967285,
       "line": 17,
       "name": "Object#c",
       "selfWeight": 0,
@@ -1305,7 +1305,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "../../alexcoco/speedscope/sample/programs/ruby/object.rb",
-      "key": "282966640558080",
+      "key": 1974665216,
       "line": undefined,
       "name": "<main>",
       "selfWeight": 0,
@@ -1314,7 +1314,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/alex/src/github.com/alexcoco/speedscope/sample/programs/ruby/object.rb",
-      "key": "286821399920640",
+      "key": 562298880,
       "line": undefined,
       "name": "<main>",
       "selfWeight": 0,
@@ -1323,7 +1323,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "<cfunc>",
-      "key": "286984498053120",
+      "key": 1576140800,
       "line": null,
       "name": "StackProf.run",
       "selfWeight": 0,
@@ -1332,7 +1332,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/alex/src/github.com/alexcoco/speedscope/sample/programs/ruby/object.rb",
-      "key": "282949341675541",
+      "key": -1739123191,
       "line": 21,
       "name": "block in <main>",
       "selfWeight": 1,
@@ -1341,7 +1341,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/alex/src/github.com/alexcoco/speedscope/sample/programs/ruby/object.rb",
-      "key": "286984366981124",
+      "key": 1673659540,
       "line": 4,
       "name": "Object#a",
       "selfWeight": 2,
@@ -1350,7 +1350,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "<cfunc>",
-      "key": "282975888998400",
+      "key": 888471552,
       "line": null,
       "name": "Range#each",
       "selfWeight": 0,
@@ -1359,7 +1359,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/alex/src/github.com/alexcoco/speedscope/sample/programs/ruby/object.rb",
-      "key": "286984364359691",
+      "key": 1693059735,
       "line": 11,
       "name": "Object#b",
       "selfWeight": 1,
@@ -1368,7 +1368,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "<cfunc>",
-      "key": "282988015779840",
+      "key": -1112014848,
       "line": null,
       "name": "Class#new",
       "selfWeight": 4,
@@ -1377,7 +1377,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/alex/src/github.com/alexcoco/speedscope/sample/programs/ruby/object.rb",
-      "key": "286984361738255",
+      "key": 1477578027,
       "line": 15,
       "name": "Object#c",
       "selfWeight": 2,
@@ -1386,7 +1386,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "<cfunc>",
-      "key": "282975857541120",
+      "key": -86704128,
       "line": null,
       "name": "Range#to_a",
       "selfWeight": 1,
@@ -1395,7 +1395,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "<cfunc>",
-      "key": "286983234519040",
+      "key": 1061289984,
       "line": null,
       "name": "Enumerable#to_a",
       "selfWeight": 36,
@@ -1404,7 +1404,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "<internal:array>",
-      "key": "282955845468220",
+      "key": -1962920788,
       "line": 60,
       "name": "Array#sample",
       "selfWeight": 20,
@@ -1413,7 +1413,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "<cfunc>",
-      "key": "282979385999360",
+      "key": 1919287296,
       "line": null,
       "name": "Array#sort",
       "selfWeight": 36,
@@ -1500,7 +1500,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "../../alexcoco/speedscope/sample/programs/ruby/object.rb",
-      "key": "282966640558080",
+      "key": 1974665216,
       "line": undefined,
       "name": "<main>",
       "selfWeight": 0,
@@ -1509,7 +1509,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/alex/src/github.com/alexcoco/speedscope/sample/programs/ruby/object.rb",
-      "key": "286821399920640",
+      "key": 562298880,
       "line": undefined,
       "name": "<main>",
       "selfWeight": 0,
@@ -1518,7 +1518,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "<cfunc>",
-      "key": "286984498053120",
+      "key": 1576140800,
       "line": null,
       "name": "StackProf.run",
       "selfWeight": 0,
@@ -1527,7 +1527,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/alex/src/github.com/alexcoco/speedscope/sample/programs/ruby/object.rb",
-      "key": "282949341675541",
+      "key": -1739123191,
       "line": 21,
       "name": "block in <main>",
       "selfWeight": 1,
@@ -1536,7 +1536,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/alex/src/github.com/alexcoco/speedscope/sample/programs/ruby/object.rb",
-      "key": "286984366981124",
+      "key": 1673659540,
       "line": 4,
       "name": "Object#a",
       "selfWeight": 2,
@@ -1545,7 +1545,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "<cfunc>",
-      "key": "282975888998400",
+      "key": 888471552,
       "line": null,
       "name": "Range#each",
       "selfWeight": 0,
@@ -1554,7 +1554,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/alex/src/github.com/alexcoco/speedscope/sample/programs/ruby/object.rb",
-      "key": "286984364359691",
+      "key": 1693059735,
       "line": 11,
       "name": "Object#b",
       "selfWeight": 1,
@@ -1563,7 +1563,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "<cfunc>",
-      "key": "282988015779840",
+      "key": -1112014848,
       "line": null,
       "name": "Class#new",
       "selfWeight": 4,
@@ -1572,7 +1572,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "/Users/alex/src/github.com/alexcoco/speedscope/sample/programs/ruby/object.rb",
-      "key": "286984361738255",
+      "key": 1477578027,
       "line": 15,
       "name": "Object#c",
       "selfWeight": 2,
@@ -1581,7 +1581,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "<cfunc>",
-      "key": "282975857541120",
+      "key": -86704128,
       "line": null,
       "name": "Range#to_a",
       "selfWeight": 1,
@@ -1590,7 +1590,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "<cfunc>",
-      "key": "286983234519040",
+      "key": 1061289984,
       "line": null,
       "name": "Enumerable#to_a",
       "selfWeight": 36,
@@ -1599,7 +1599,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "<internal:array>",
-      "key": "282955845468220",
+      "key": -1962920788,
       "line": 60,
       "name": "Array#sample",
       "selfWeight": 20,
@@ -1608,7 +1608,7 @@ Object {
     Frame {
       "col": undefined,
       "file": "<cfunc>",
-      "key": "282979385999360",
+      "key": 1919287296,
       "line": null,
       "name": "(unknown)",
       "selfWeight": 36,


### PR DESCRIPTION
Combine frame id with line number using bitwise to try and keep the key within 53 bits.

Collisions should be unlikely but this won't win any awards for best hasher. Tries to optimize for the frame address being at most 48 bits, and the line number being unable to exceed 16 bits. XOR with itself and prime number before bit shifting to further reduce loss of precision

Should be much faster than string operations, but might come at the cost of correctness in rare cases.